### PR TITLE
WiFiClientSecure v1.0.6 needs certificate

### DIFF
--- a/IOTA-price-ticker-V2_1-TTGO-T-Display/IOTA-price-ticker-V2_1-TTGO-T-Display.ino
+++ b/IOTA-price-ticker-V2_1-TTGO-T-Display/IOTA-price-ticker-V2_1-TTGO-T-Display.ino
@@ -110,6 +110,8 @@ void setup()
     delay(1000);
     tft.fillRect(0, 0, 240, 135, TFT_BLACK);
 
+    client.setInsecure();
+    
     tft.pushImage(0, 0, iota2Width, iota2Height, iota2);
 }
 


### PR DESCRIPTION
this one line lets WiFiClientSecure connect without validating the chain - which seems like a perfectly fine thing to do in this case, we're just doing a GET on an API of publicly known date.